### PR TITLE
package/qt6: bump version to 6.7.3

### DIFF
--- a/package/qt6/qt6.mk
+++ b/package/qt6/qt6.mk
@@ -5,7 +5,7 @@
 ################################################################################
 # REG: bump
 QT6_VERSION_MAJOR = 6.7
-QT6_VERSION = $(QT6_VERSION_MAJOR).2
+QT6_VERSION = $(QT6_VERSION_MAJOR).3
 QT6_SOURCE_TARBALL_PREFIX = everywhere-src
 QT6_SITE = https://download.qt.io/archive/qt/$(QT6_VERSION_MAJOR)/$(QT6_VERSION)/submodules
 

--- a/package/qt6/qt6base/qt6base.hash
+++ b/package/qt6/qt6base/qt6base.hash
@@ -1,6 +1,5 @@
-# Hash from: https://download.qt.io/official_releases/qt/6.6/6.6.3/submodules/qtbase-everywhere-src-6.6.3.tar.xz.sha256
-sha256  c5f22a5e10fb162895ded7de0963328e7307611c688487b5d152c9ee64767599  qtbase-everywhere-src-6.7.2.tar.xz
-sha256  0493fd0b380c4edf8872f011a7f26d245aa4cdd75b349904ef340a22dedf7462  qtbase-everywhere-src-6.6.3.tar.xz
+# Hash from: https://download.qt.io/official_releases/qt/6.7/6.7.3/submodules/qtbase-everywhere-src-6.7.3.tar.xz.sha256
+sha256  8ccbb9ab055205ac76632c9eeddd1ed6fc66936fc56afc2ed0fd5d9e23da3097  qtbase-everywhere-src-6.7.3.tar.xz
 
 # Hashes for license files
 sha256  e3ba223bb1423f0aad8c3dfce0fe3148db48926d41e6fbc3afbbf5ff9e1c89cb  LICENSES/Apache-2.0.txt

--- a/package/qt6/qt6base/qt6base.mk
+++ b/package/qt6/qt6base/qt6base.mk
@@ -9,23 +9,6 @@ QT6BASE_SITE = $(QT6_SITE)
 QT6BASE_SOURCE = qtbase-$(QT6_SOURCE_TARBALL_PREFIX)-$(QT6BASE_VERSION).tar.xz
 QT6BASE_CPE_ID_VENDOR = qt
 QT6BASE_CPE_ID_PRODUCT = qt
-# 0001-QDnsLookup-Unix-make-sure-we-don-t-overflow-the-buff.patch
-QT6BASE_IGNORE_CVES += CVE-2023-33285
-# 0002-Hsts-match-header-names-case-insensitively.patch
-QT6BASE_IGNORE_CVES += CVE-2023-32762
-# 0005-Fix-specific-overflow-in-qtextlayout.patch
-QT6BASE_IGNORE_CVES += CVE-2023-32763
-# 0009-QXmlStreamReader-Raise-error-on-unexpected-tokens.patch
-QT6BASE_IGNORE_CVES += CVE-2023-38197
-# 0011-HPack-fix-incorrect-integer-overflow-check.patch
-QT6BASE_IGNORE_CVES += CVE-2023-38197
-# 0013-QXmlStreamReader-make-fastScanName-indicate-parsing-.patch
-QT6BASE_IGNORE_CVES += CVE-2023-37369
-# 0014-Schannel-Reject-certificate-not-signed-by-a-configur.patch
-# 0015-Ssl-Copy-the-on-demand-cert-loading-bool-from-defaul.patch
-QT6BASE_IGNORE_CVES += CVE-2023-34410
-# 0016-HTTP2-Delay-any-communication-until-encrypted-can-be.patch
-QT6BASE_IGNORE_CVES += CVE-2024-39936
 
 QT6BASE_CMAKE_BACKEND = ninja
 

--- a/package/qt6/qt6core5compat/qt6core5compat.hash
+++ b/package/qt6/qt6core5compat/qt6core5compat.hash
@@ -1,5 +1,5 @@
-# Hash from: https://download.qt.io/official_releases/qt/6.6/6.6.3/submodules/qtserialport-everywhere-src-6.6.3.tar.xz.sha256
-sha256  e1656579e555da61cb81cbbb5ee6d31835cea110b3a5dd9e14b16fa71e55dc37  qtserialport-everywhere-src-6.6.3.tar.xz
+# Hash from: https://download.qt.io/official_releases/qt/6.7/6.7.3/submodules/qt5compat-everywhere-src-6.7.3.tar.xz.sha256
+sha256  8b6a68a3dfaa7e9d10a0dafccee594c72e8de061bc573ae86b1c081b423a53f0  qt5compat-everywhere-src-6.7.3.tar.xz
 
 # Hashes for license files:
 sha256  9f0490f18656c6f2435bd14f603ef0c96434d1825615363dce43abb42ed1dcce  LICENSES/BSD-3-Clause.txt

--- a/package/qt6/qt6serialbus/qt6serialbus.hash
+++ b/package/qt6/qt6serialbus/qt6serialbus.hash
@@ -1,5 +1,5 @@
-# Hash from: https://download.qt.io/official_releases/qt/6.6/6.6.3/submodules/qtserialbus-everywhere-src-6.6.3.tar.xz.sha256
-sha256  143e5afcb81a2e2a92d5c0f16679295349d0b8e1ee398230a391ca5be00ad0fb  qtserialbus-everywhere-src-6.6.3.tar.xz
+# Hash from: https://download.qt.io/official_releases/qt/6.7/6.7.3/submodules/qtserialbus-everywhere-src-6.7.3.tar.xz.sha256
+sha256  55d82e9c7a827808b7383f0a57ad12c2a6fcf5b6c936b27e633155163c0a6276  qtserialbus-everywhere-src-6.7.3.tar.xz
 
 # Hashes for license files:
 sha256  9f0490f18656c6f2435bd14f603ef0c96434d1825615363dce43abb42ed1dcce  LICENSES/BSD-3-Clause.txt

--- a/package/qt6/qt6serialport/qt6serialport.hash
+++ b/package/qt6/qt6serialport/qt6serialport.hash
@@ -1,5 +1,5 @@
-# Hash from: https://download.qt.io/official_releases/qt/6.6/6.6.3/submodules/qtserialport-everywhere-src-6.6.3.tar.xz.sha256
-sha256  e1656579e555da61cb81cbbb5ee6d31835cea110b3a5dd9e14b16fa71e55dc37  qtserialport-everywhere-src-6.6.3.tar.xz
+# Hash from: https://download.qt.io/official_releases/qt/6.7/6.7.3/submodules/qtserialport-everywhere-src-6.7.3.tar.xz.sha256
+sha256  d4fa58ee809b39c9eda8d20ee4677971e918edb9a076540466693bc46db146f0  qtserialport-everywhere-src-6.7.3.tar.xz
 
 # Hashes for license files:
 sha256  9f0490f18656c6f2435bd14f603ef0c96434d1825615363dce43abb42ed1dcce  LICENSES/BSD-3-Clause.txt

--- a/package/qt6/qt6svg/qt6svg.hash
+++ b/package/qt6/qt6svg/qt6svg.hash
@@ -1,6 +1,5 @@
-# Hash from: https://download.qt.io/official_releases/qt/6.6/6.6.3/submodules/qtsvg-everywhere-src-6.6.3.tar.xz.sha256
-sha256  fb0d1286a35be3583fee34aeb5843c94719e07193bdf1d4d8b0dc14009caef01  qtsvg-everywhere-src-6.7.2.tar.xz
-sha256  4acb1e576eca55e955cf2b0d15c914a200df290e737accd7c1901fa1e33a25c7  qtsvg-everywhere-src-6.6.3.tar.xz
+# Hash from: https://download.qt.io/official_releases/qt/6.7/6.7.3/submodules/qtsvg-everywhere-src-6.7.3.tar.xz.sha256
+sha256  40142cb71fb1e07ad612bc361b67f5d54cd9367f9979ae6b86124a064deda06b  qtsvg-everywhere-src-6.7.3.tar.xz
 
 # Hashes for license files:
 sha256  9f0490f18656c6f2435bd14f603ef0c96434d1825615363dce43abb42ed1dcce  LICENSES/BSD-3-Clause.txt


### PR DESCRIPTION
For details see:

https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.7.3/release-note.md

I have removed a couple of patches here, since they are included in this version:

 - CVE-2024-39936  (qtbase)
 - QTBUG-125066 Configure fails in qttools if PrintSupport is disabled  (qttools)

Please do not submit a Pull Request via GitHub. Buildroot makes use of a
[mailing list](http://lists.buildroot.org/mailman/listinfo/buildroot) for patch submission and review.
See [submitting your own patches](http://buildroot.org/manual.html#submitting-patches) for more info.

Thanks for your help!

